### PR TITLE
bug: fix windowリサイズイベントの引数がundefined になりinnerWidthを取れない問題を修正

### DIFF
--- a/packages/core/src/infrastructure/clock-dom.ts
+++ b/packages/core/src/infrastructure/clock-dom.ts
@@ -767,9 +767,9 @@ class WindowResizeSignal {
       window.removeEventListener("resize", this.onResize);
     }
   }
-  private onResize = (ev: UIEvent) => {
+  private onResize = (_ev: UIEvent) => {
     for (const handler of this.handlers) {
-      handler(ev.target as Window);
+      handler(window);
     }
   };
 }


### PR DESCRIPTION
- windowオブジェクトが渡されることを実機で確認