### PR TITLE
Feature VectorWithSnapshots/ClockWithDisposables 追加, SimulatorContext.disposables を削除

### DIFF
--- a/packages/core/src/adaptors/composite.ts
+++ b/packages/core/src/adaptors/composite.ts
@@ -1,0 +1,52 @@
+import type { ClockPort, DisposablePort, SnapshotPort, VectorReadablePort } from "../ports";
+
+/**
+ * VectorReadablePortとsnapshotの対象には含めたいPortをまとめるためのクラス。
+ * @param source vector()で利用されるVectorReadablePort
+ * @param snapshots vectorとして利用しないがsnapshotの対象となるSnapshotPort群
+ */
+export class VectorWithSnapshots implements VectorReadablePort {
+  private readonly _dependencies: SnapshotPort[];
+  constructor(
+    private readonly source: VectorReadablePort,
+    ...snapshots: SnapshotPort[]
+  ) {
+    this._dependencies = snapshots;
+  }
+  public vector(): Readonly<number[]> {
+    return this.source.vector();
+  }
+  public snapshot(now: number): void {
+    this.source.snapshot(now);
+  }
+  public dependencies(): SnapshotPort[] {
+    return this._dependencies;
+  }
+}
+
+/**
+ * ClockとdestroyされるべきDisposablePort群をまとめるためのクラス。
+ * @param clock Clockとして利用されるClockPort
+ * @param disposables Clockとして利用しないが、destroyの対象には含めたいDisposablePort群
+ */
+export class ClockWithDisposables implements ClockPort {
+  private readonly _disposables: DisposablePort[];
+  constructor(
+    private readonly clock: ClockPort,
+    ...disposables: DisposablePort[]
+  ) {
+    this._disposables = disposables;
+  }
+  public onHeartbeat(cb: () => void): void {
+    this.clock.onHeartbeat(cb);
+  }
+  public isActive(): boolean {
+    return this.clock.isActive();
+  }
+  public destroy(): void {
+    this.clock.destroy();
+    for (const disposable of this._disposables) {
+      disposable.destroy();
+    }
+  }
+}

--- a/packages/core/src/adaptors/index.ts
+++ b/packages/core/src/adaptors/index.ts
@@ -1,4 +1,5 @@
 export * from "./adaptor";
+export * from "./composite";
 export * from "./gate";
 export * from "./position";
 export * from "./resolver";

--- a/packages/core/src/simulator/context.ts
+++ b/packages/core/src/simulator/context.ts
@@ -1,17 +1,8 @@
-import type {
-  ClockPort,
-  DisposablePort,
-  KineticsPort,
-  PhysicsPort,
-  VectorReadablePort,
-} from "../ports";
+import type { ClockPort, KineticsPort, PhysicsPort, VectorReadablePort } from "../ports";
 
 export type SimulationContext = {
   clock: ClockPort;
-  kinetics: KineticsPort;
   target: VectorReadablePort;
+  kinetics: KineticsPort;
   physics: PhysicsPort | PhysicsPort[];
-  // simulation終了時にSimulator.destroy()によってdestroyされるべきインスタンス群。
-  // Clockはauto disposeされるため、ここに含める必要は必ずしもない。
-  disposables?: DisposablePort[];
 };

--- a/packages/core/src/simulator/simulator.ts
+++ b/packages/core/src/simulator/simulator.ts
@@ -75,11 +75,8 @@ export class Simulator {
 
   public destroy(): void {
     this.pause();
-    for (const { clock, disposables } of this.contexts) {
+    for (const { clock } of this.contexts) {
       clock.destroy();
-      for (const d of disposables || []) {
-        d.destroy();
-      }
     }
     this.contexts = [];
   }


### PR DESCRIPTION
- Vectorとして利用しないが、snapshotを取ってほしい実装
- Clock として利用しないが、distroyされるべき実装