### PR TITLE
ref: KineticsPortを最小限に変更しKineticsで明示的にVectorをimpl/ClonableKineticsPortを追加

### DIFF
--- a/packages/core/src/kinesis/kinetics.ts
+++ b/packages/core/src/kinesis/kinetics.ts
@@ -1,5 +1,5 @@
 import type {
-  ClonableKineticsPort,
+  CloneableKineticsPort,
   EnginePort,
   EngineResult,
   KineticsPort,
@@ -9,7 +9,7 @@ import type { SimulationState } from "../state";
 import { SpringEngine } from "./engines/spring-engine";
 import type { Options } from "./options";
 
-export class Kinetics implements KineticsPort, ClonableKineticsPort, VectorReadablePort {
+export class Kinetics implements KineticsPort, CloneableKineticsPort, VectorReadablePort {
   public static readonly ACTIVITY_THRESHOLD = 0.001;
   private _state: SimulationState = {
     ndim: 0,

--- a/packages/core/src/kinesis/kinetics.ts
+++ b/packages/core/src/kinesis/kinetics.ts
@@ -1,9 +1,9 @@
-import type { EnginePort, EngineResult, KineticsPort, VectorReadablePort } from "../ports";
+import type { EnginePort, EngineResult, KineticsPort } from "../ports";
 import type { SimulationState } from "../state";
 import { SpringEngine } from "./engines/spring-engine";
 import type { Options } from "./options";
 
-export class Kinetics implements KineticsPort, VectorReadablePort {
+export class Kinetics implements KineticsPort {
   public static readonly ACTIVITY_THRESHOLD = 0.001;
   private _state: SimulationState = {
     ndim: 0,

--- a/packages/core/src/kinesis/kinetics.ts
+++ b/packages/core/src/kinesis/kinetics.ts
@@ -1,9 +1,15 @@
-import type { EnginePort, EngineResult, KineticsPort, VectorReadablePort } from "../ports";
+import type {
+  ClonableKineticsPort,
+  EnginePort,
+  EngineResult,
+  KineticsPort,
+  VectorReadablePort,
+} from "../ports";
 import type { SimulationState } from "../state";
 import { SpringEngine } from "./engines/spring-engine";
 import type { Options } from "./options";
 
-export class Kinetics implements KineticsPort, VectorReadablePort {
+export class Kinetics implements KineticsPort, ClonableKineticsPort, VectorReadablePort {
   public static readonly ACTIVITY_THRESHOLD = 0.001;
   private _state: SimulationState = {
     ndim: 0,
@@ -65,6 +71,20 @@ export class Kinetics implements KineticsPort, VectorReadablePort {
 
   public get state() {
     return this._state;
+  }
+
+  public clone(): KineticsPort {
+    const clone = new Kinetics([]);
+    clone._state = {
+      ndim: this._state.ndim,
+      absolute: [...this._state.absolute],
+      relative: [...this._state.relative],
+      velocity: [...this._state.velocity],
+      activityLevel: this._state.activityLevel,
+    };
+    clone.engines = [...this.engines];
+    clone._snapshot = [...this._snapshot];
+    return clone;
   }
 
   public setEngine(engine: EnginePort | EnginePort[]) {

--- a/packages/core/src/kinesis/kinetics.ts
+++ b/packages/core/src/kinesis/kinetics.ts
@@ -1,9 +1,9 @@
-import type { EnginePort, EngineResult, KineticsPort } from "../ports";
+import type { EnginePort, EngineResult, KineticsPort, VectorReadablePort } from "../ports";
 import type { SimulationState } from "../state";
 import { SpringEngine } from "./engines/spring-engine";
 import type { Options } from "./options";
 
-export class Kinetics implements KineticsPort {
+export class Kinetics implements KineticsPort, VectorReadablePort {
   public static readonly ACTIVITY_THRESHOLD = 0.001;
   private _state: SimulationState = {
     ndim: 0,

--- a/packages/core/src/ports/kinetics-port.ts
+++ b/packages/core/src/ports/kinetics-port.ts
@@ -1,8 +1,8 @@
 import type { SimulationState } from "../state";
 import type { ActivityPort } from "./activity-port";
-import type { SnapshotPort } from "./snapshot-port";
+import type { VectorReadablePort } from "./readable-port";
 
-export interface KineticsPort extends ActivityPort, SnapshotPort {
+export interface KineticsPort extends ActivityPort, VectorReadablePort {
   compute(dt: number, vector: Readonly<number[]>): void;
   readonly state: SimulationState;
 }

--- a/packages/core/src/ports/kinetics-port.ts
+++ b/packages/core/src/ports/kinetics-port.ts
@@ -5,3 +5,7 @@ export interface KineticsPort extends ActivityPort {
   compute(dt: number, vector: Readonly<number[]>): void;
   readonly state: SimulationState;
 }
+
+export interface ClonableKineticsPort {
+  clone(): KineticsPort;
+}

--- a/packages/core/src/ports/kinetics-port.ts
+++ b/packages/core/src/ports/kinetics-port.ts
@@ -6,6 +6,6 @@ export interface KineticsPort extends ActivityPort {
   readonly state: SimulationState;
 }
 
-export interface ClonableKineticsPort {
+export interface CloneableKineticsPort {
   clone(): KineticsPort;
 }

--- a/packages/core/src/ports/kinetics-port.ts
+++ b/packages/core/src/ports/kinetics-port.ts
@@ -1,8 +1,7 @@
 import type { SimulationState } from "../state";
 import type { ActivityPort } from "./activity-port";
-import type { VectorReadablePort } from "./readable-port";
 
-export interface KineticsPort extends ActivityPort, VectorReadablePort {
+export interface KineticsPort extends ActivityPort {
   compute(dt: number, vector: Readonly<number[]>): void;
   readonly state: SimulationState;
 }


### PR DESCRIPTION
- simulator.contextでの利用を考慮して最小限に変更
- 実際として実装でVectorをimplすれば十分
- [add: kinetics.clone メソッドでsandbox的に破壊的な変更が可能に](https://github.com/yyyoichi/chrono-kinesis/pull/45/commits/0161d4bab00b7f352f7e735827b8b1276eb8f4a0) 
[0161d4b](https://github.com/yyyoichi/chrono-kinesis/pull/45/commits/0161d4bab00b7f352f7e735827b8b1276eb8f4a0)
- 将来的に運動の減退を考慮した将来予測に利用する想定